### PR TITLE
Port to Python3

### DIFF
--- a/sendreceivesigfox.py
+++ b/sendreceivesigfox.py
@@ -47,19 +47,19 @@ def ReceiveUntil(ser, success, failure, timeOut):
 	if success in currentMsg :
 		return currentMsg
 	elif failure in currentMsg :
-		print 'Failure (' + currentMsg.replace('\r\n', '') + ')'
+		print('Failure (' + currentMsg.replace('\r\n', '') + ')')
 	else :
-		print 'Receive timeout (' + currentMsg.replace('\r\n', '') + ')'
+		print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
 	return ''
 
-print 'Sending SigFox Message...'
+print('Sending SigFox Message...')
 
 # allow serial port choice from parameter - default is /dev/ttyAMA0
 portName = '/dev/ttyAMA0'
 if len(sys.argv) == 3:
     portName = sys.argv[2]
 
-print 'Serial port : ' + portName
+print('Serial port : ' + portName)
 
 ser = serial.Serial(
 	port=portName,
@@ -118,6 +118,6 @@ else:
 	ser.close()
 	exit()
 
-print re.sub(r'\+RX=([0-9af ]{2,})\+RX END', r'\1', rxData.replace('\r\n', ''))
+print(re.sub(r'\+RX=([0-9af ]{2,})\+RX END', r'\1', rxData.replace('\r\n', '')))
 
 ser.close()

--- a/sendreceivesigfox.py
+++ b/sendreceivesigfox.py
@@ -35,22 +35,22 @@ def WaitFor(ser, success, failure, timeOut):
     return ReceiveUntil(ser, success, failure, timeOut) != ''
 
 def ReceiveUntil(ser, success, failure, timeOut):
-	iterCount = timeOut / 0.1
-	ser.timeout = 0.1
-	currentMsg = ''
-	while iterCount >= 0 and success not in currentMsg and failure not in currentMsg :
-		sleep(0.1)
-		while ser.inWaiting() > 0 :
-			c = ser.read()
-			currentMsg += c
-		iterCount -= 1
-	if success in currentMsg :
-		return currentMsg
-	elif failure in currentMsg :
-		print('Failure (' + currentMsg.replace('\r\n', '') + ')')
-	else :
-		print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
-	return ''
+    iterCount = timeOut / 0.1
+    ser.timeout = 0.1
+    currentMsg = ''
+    while iterCount >= 0 and success not in currentMsg and failure not in currentMsg :
+        sleep(0.1)
+        while ser.inWaiting() > 0 :
+            c = ser.read()
+            currentMsg += c
+        iterCount -= 1
+    if success in currentMsg:
+        return currentMsg
+    elif failure in currentMsg:
+        print('Failure (' + currentMsg.replace('\r\n', '') + ')')
+    else :
+        print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
+    return ''
 
 print('Sending SigFox Message...')
 
@@ -62,14 +62,14 @@ if len(sys.argv) == 3:
 print('Serial port : ' + portName)
 
 ser = serial.Serial(
-	port=portName,
-	baudrate=9600,
-	parity=serial.PARITY_NONE,
-	stopbits=serial.STOPBITS_ONE,
-	bytesize=serial.EIGHTBITS
+    port=portName,
+    baudrate=9600,
+    parity=serial.PARITY_NONE,
+    stopbits=serial.STOPBITS_ONE,
+    bytesize=serial.EIGHTBITS
 )
 
-if ser.isOpen() : # on some platforms the serial port needs to be closed first 
+if ser.isOpen(): # on some platforms the serial port needs to be closed first 
     ser.close()
 
 try:
@@ -80,43 +80,43 @@ except serial.SerialException as e:
 
 ser.write('AT\r')
 if WaitFor(ser, 'OK', 'ERROR', 3) :
-	print('SigFox Modem OK')
+    print('SigFox Modem OK')
 else:
-	print('SigFox Modem Init Error')
-	ser.close()
-	exit()
+    print('SigFox Modem Init Error')
+    ser.close()
+    exit()
 
 ser.write('ATE0\r')
 if WaitFor(ser, 'OK', 'ERROR', 3) :
-	print('SigFox Modem echo OFF')
+    print('SigFox Modem echo OFF')
 else:
-	print('SigFox Modem Configuration Error')
-	ser.close()
-	exit()
+    print('SigFox Modem Configuration Error')
+    ser.close()
+    exit()
 
 ser.write("AT$SF={0},2,1\r".format(sys.argv[1]))
 print('Sending ...')
 if WaitFor(ser, 'OK', 'ERROR', 25) :
-	print('Message sent')
+    print('Message sent')
 else:
-	print('Error sending message')
-	ser.close()
-	exit()
+    print('Error sending message')
+    ser.close()
+    exit()
 
 if WaitFor(ser, 'BEGIN', 'ERROR', 25) :
-	print('Waiting for answer')
+    print('Waiting for answer')
 else:
-	print('Error waiting for answer')
-	ser.close()
-	exit()
+    print('Error waiting for answer')
+    ser.close()
+    exit()
 
 rxData = ReceiveUntil(ser, 'END', 'ERROR', 25)
 if rxData != '' :
-	print('Answer received')
+    print('Answer received')
 else:
-	print('Error receiving answer')
-	ser.close()
-	exit()
+    print('Error receiving answer')
+    ser.close()
+    exit()
 
 print(re.sub(r'\+RX=([0-9af ]{2,})\+RX END', r'\1', rxData.replace('\r\n', '')))
 

--- a/sendreceivesigfox.py
+++ b/sendreceivesigfox.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 ## @package rpisigfox
 #  This script allow the control of the rpisigfox expansion board for Raspberry Pi.
@@ -10,113 +10,32 @@
 #  Example : sendsigfox 00AA55BF to send the 4 bytes 0x00 0xAA 0x55 0xBF
 # 
 
-import serial
+import logging
 import sys
-import re
-from time import sleep
 
-SOH = chr(0x01)
-STX = chr(0x02)
-EOT = chr(0x04)
-ACK = chr(0x06)
-NAK = chr(0x15)
-CAN = chr(0x18)
-CRC = chr(0x43)
+from sigfox import Sigfox
 
-def getc(size, timeout=1):
-    return ser.read(size)
+if __name__ == '__main__':
+    DEFAULT_PORT = '/dev/ttyAMA0'
+    DEFAULT_MESSAGE = "1234CAFE"
 
-def putc(data, timeout=1):
-    ser.write(data)
-    sleep(0.001) # give device time to prepare new buffer and start sending it
+    print('Sending SigFox Message...')
+    # allow serial port choice from parameter - default is /dev/ttyAMA0
+    try:
+        port_name = sys.argv[2]
+        print('Serial port : ' + port_name)
+    except IndexError:
+        port_name = DEFAULT_PORT
+    sgfx = Sigfox(port_name)
 
-def WaitFor(ser, success, failure, timeOut):
-    return ReceiveUntil(ser, success, failure, timeOut) != ''
+    try:
+        message = bytes.fromhex(sys.argv[1])
+    except IndexError:
+        message = bytes.fromhex(DEFAULT_MESSAGE)
+    logging.getLogger().setLevel(logging.INFO)
+    response = sgfx.send_receive_message(message)
 
-def ReceiveUntil(ser, success, failure, timeOut):
-    iterCount = timeOut / 0.1
-    ser.timeout = 0.1
-    currentMsg = ''
-    while iterCount >= 0 and success not in currentMsg and failure not in currentMsg :
-        sleep(0.1)
-        while ser.inWaiting() > 0 :
-            c = ser.read()
-            currentMsg += c
-        iterCount -= 1
-    if success in currentMsg:
-        return currentMsg
-    elif failure in currentMsg:
-        print('Failure (' + currentMsg.replace('\r\n', '') + ')')
-    else :
-        print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
-    return ''
-
-print('Sending SigFox Message...')
-
-# allow serial port choice from parameter - default is /dev/ttyAMA0
-portName = '/dev/ttyAMA0'
-if len(sys.argv) == 3:
-    portName = sys.argv[2]
-
-print('Serial port : ' + portName)
-
-ser = serial.Serial(
-    port=portName,
-    baudrate=9600,
-    parity=serial.PARITY_NONE,
-    stopbits=serial.STOPBITS_ONE,
-    bytesize=serial.EIGHTBITS
-)
-
-if ser.isOpen(): # on some platforms the serial port needs to be closed first
-    ser.close()
-
-try:
-    ser.open()
-except serial.SerialException as e:
-    sys.stderr.write("Could not open serial port {}: {}\n".format(ser.name, e))
-    sys.exit(1)
-
-ser.write('AT\r')
-if WaitFor(ser, 'OK', 'ERROR', 3):
-    print('SigFox Modem OK')
-else:
-    print('SigFox Modem Init Error')
-    ser.close()
-    exit()
-
-ser.write('ATE0\r')
-if WaitFor(ser, 'OK', 'ERROR', 3):
-    print('SigFox Modem echo OFF')
-else:
-    print('SigFox Modem Configuration Error')
-    ser.close()
-    exit()
-
-ser.write("AT$SF={0},2,1\r".format(sys.argv[1]))
-print('Sending ...')
-if WaitFor(ser, 'OK', 'ERROR', 25):
-    print('Message sent')
-else:
-    print('Error sending message')
-    ser.close()
-    exit()
-
-if WaitFor(ser, 'BEGIN', 'ERROR', 25):
-    print('Waiting for answer')
-else:
-    print('Error waiting for answer')
-    ser.close()
-    exit()
-
-rxData = ReceiveUntil(ser, 'END', 'ERROR', 25)
-if rxData != '':
-    print('Answer received')
-else:
-    print('Error receiving answer')
-    ser.close()
-    exit()
-
-print(re.sub(r'\+RX=([0-9af ]{2,})\+RX END', r'\1', rxData.replace('\r\n', '')))
-
-ser.close()
+    if response:
+        print(response)
+    else:
+        print("No response")

--- a/sendreceivesigfox.py
+++ b/sendreceivesigfox.py
@@ -5,12 +5,11 @@
 #
 #  V1.0 allow only to send regular message on the SigFox Network.
 #  syntax is :
-#  sendsigfox MESSAGE 
+#  sendsigfox MESSAGE
 #  where MESSAGE is an HEXA string encoded. Can be 2 to 24 characters representing 1 to 12 bytes.
 #  Example : sendsigfox 00AA55BF to send the 4 bytes 0x00 0xAA 0x55 0xBF
 # 
 
-import time
 import serial
 import sys
 import re
@@ -69,7 +68,7 @@ ser = serial.Serial(
     bytesize=serial.EIGHTBITS
 )
 
-if ser.isOpen(): # on some platforms the serial port needs to be closed first 
+if ser.isOpen(): # on some platforms the serial port needs to be closed first
     ser.close()
 
 try:
@@ -79,7 +78,7 @@ except serial.SerialException as e:
     sys.exit(1)
 
 ser.write('AT\r')
-if WaitFor(ser, 'OK', 'ERROR', 3) :
+if WaitFor(ser, 'OK', 'ERROR', 3):
     print('SigFox Modem OK')
 else:
     print('SigFox Modem Init Error')
@@ -87,7 +86,7 @@ else:
     exit()
 
 ser.write('ATE0\r')
-if WaitFor(ser, 'OK', 'ERROR', 3) :
+if WaitFor(ser, 'OK', 'ERROR', 3):
     print('SigFox Modem echo OFF')
 else:
     print('SigFox Modem Configuration Error')
@@ -96,14 +95,14 @@ else:
 
 ser.write("AT$SF={0},2,1\r".format(sys.argv[1]))
 print('Sending ...')
-if WaitFor(ser, 'OK', 'ERROR', 25) :
+if WaitFor(ser, 'OK', 'ERROR', 25):
     print('Message sent')
 else:
     print('Error sending message')
     ser.close()
     exit()
 
-if WaitFor(ser, 'BEGIN', 'ERROR', 25) :
+if WaitFor(ser, 'BEGIN', 'ERROR', 25):
     print('Waiting for answer')
 else:
     print('Error waiting for answer')
@@ -111,7 +110,7 @@ else:
     exit()
 
 rxData = ReceiveUntil(ser, 'END', 'ERROR', 25)
-if rxData != '' :
+if rxData != '':
     print('Answer received')
 else:
     print('Error receiving answer')

--- a/sendsigfox.py
+++ b/sendsigfox.py
@@ -28,7 +28,7 @@ class Sigfox(object):
         # allow serial port choice from parameter - default is /dev/ttyAMA0
         portName = port
         
-        print 'Serial port : ' + portName
+        print('Serial port : ' + portName)
         self.ser = serial.Serial(
                 port=portName,
                 baudrate=9600,
@@ -60,13 +60,13 @@ class Sigfox(object):
             if success in currentMsg :
                     return currentMsg
             elif failure in currentMsg :
-                    print 'Failure (' + currentMsg.replace('\r\n', '') + ')'
+                    print('Failure (' + currentMsg.replace('\r\n', '') + ')')
             else :
-                    print 'Receive timeout (' + currentMsg.replace('\r\n', '') + ')'
+                    print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
             return ''
 
     def sendMessage(self, message):
-        print 'Sending SigFox Message...'
+        print('Sending SigFox Message...')
         
         if(self.ser.isOpen() == True): # on some platforms the serial port needs to be closed first 
             self.ser.close()
@@ -87,7 +87,7 @@ class Sigfox(object):
                         print('OK Message sent')
 
         else:
-                print 'SigFox Modem Error'
+                print('SigFox Modem Error')
 
         self.ser.close()
 

--- a/sendsigfox.py
+++ b/sendsigfox.py
@@ -10,7 +10,6 @@
 #  Example : sendsigfox 00AA55BF to send the 4 bytes 0x00 0xAA 0x55 0xBF
 # 
 
-import time
 import serial
 import sys
 from time import sleep
@@ -27,14 +26,14 @@ class Sigfox(object):
     def __init__(self, port):
         # allow serial port choice from parameter - default is /dev/ttyAMA0
         portName = port
-        
+
         print('Serial port : ' + portName)
         self.ser = serial.Serial(
-                port=portName,
-                baudrate=9600,
-                parity=serial.PARITY_NONE,
-                stopbits=serial.STOPBITS_ONE,
-                bytesize=serial.EIGHTBITS
+            port=portName,
+            baudrate=9600,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_ONE,
+            bytesize=serial.EIGHTBITS
         )
 
     def getc(self, size, timeout=1):
@@ -48,27 +47,27 @@ class Sigfox(object):
         return self.ReceiveUntil(success, failure, timeOut) != ''
 
     def ReceiveUntil(self, success, failure, timeOut):
-            iterCount = timeOut / 0.1
-            self.ser.timeout = 0.1
-            currentMsg = ''
-            while iterCount >= 0 and success not in currentMsg and failure not in currentMsg :
-                    sleep(0.1)
-                    while self.ser.inWaiting() > 0 : # bunch of data ready for reading
-                            c = self.ser.read()
-                            currentMsg += c
-                    iterCount -= 1
-            if success in currentMsg :
-                    return currentMsg
-            elif failure in currentMsg :
-                    print('Failure (' + currentMsg.replace('\r\n', '') + ')')
-            else :
-                    print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
-            return ''
+        iterCount = timeOut / 0.1
+        self.ser.timeout = 0.1
+        currentMsg = ''
+        while iterCount >= 0 and success not in currentMsg and failure not in currentMsg :
+            sleep(0.1)
+            while self.ser.inWaiting() > 0 : # bunch of data ready for reading
+                c = self.ser.read()
+                currentMsg += c
+            iterCount -= 1
+        if success in currentMsg :
+            return currentMsg
+        elif failure in currentMsg :
+            print('Failure (' + currentMsg.replace('\r\n', '') + ')')
+        else :
+            print('Receive timeout (' + currentMsg.replace('\r\n', '') + ')')
+        return ''
 
     def sendMessage(self, message):
         print('Sending SigFox Message...')
-        
-        if(self.ser.isOpen() == True): # on some platforms the serial port needs to be closed first 
+
+        if self.ser.isOpen() == True: # on some platforms the serial port needs to be closed first 
             self.ser.close()
 
         try:
@@ -79,26 +78,26 @@ class Sigfox(object):
 
         self.ser.write('AT\r')
         if self.WaitFor('OK', 'ERROR', 3) :
-                print('SigFox Modem OK')
+            print('SigFox Modem OK')
 
-                self.ser.write("AT$SS={0}\r".format(message))
-                print('Sending ...')
-                if self.WaitFor('OK', 'ERROR', 15) :
-                        print('OK Message sent')
+            self.ser.write("AT$SS={0}\r".format(message))
+            print('Sending ...')
+            if self.WaitFor('OK', 'ERROR', 15) :
+                print('OK Message sent')
 
         else:
-                print('SigFox Modem Error')
+            print('SigFox Modem Error')
 
         self.ser.close()
 
 if __name__ == '__main__':
-    
+
     if len(sys.argv) == 3:
-            portName = sys.argv[2]
-            sgfx = Sigfox(portName)
+        portName = sys.argv[2]
+        sgfx = Sigfox(portName)
     else:
         sgfx = Sigfox('/dev/ttyAMA0')
-        
+
     message = "1234CAFE"
     if len(sys.argv) > 1:
         message = "{0}".format(sys.argv[1])

--- a/sendsigfox.py
+++ b/sendsigfox.py
@@ -12,105 +12,23 @@
 
 import logging
 import sys
-from time import sleep
 
-import serial
-
-class Sigfox:
-    SOH = chr(0x01)
-    STX = chr(0x02)
-    EOT = chr(0x04)
-    ACK = chr(0x06)
-    NAK = chr(0x15)
-    CAN = chr(0x18)
-    CRC = chr(0x43)
-    MAX_UPLINK_LENGTH = 12 # in bytes
-
-    def __init__(self, port="/dev/ttyAMA0", timeout=None):
-        logging.debug('Serial port : {}'.format(port))
-        self.ser = serial.Serial(
-            port=port,
-            baudrate=9600,
-            parity=serial.PARITY_NONE,
-            stopbits=serial.STOPBITS_ONE,
-            bytesize=serial.EIGHTBITS,
-            timeout=timeout
-        )
-
-    def wait_for(self, success, failure, timeout):
-        return self.receive_until(success, failure, timeout).decode() != ''
-
-    def receive_until(self, success, failure, timeout):
-        old_timeout = self.ser.timeout
-        self.ser.timeout = timeout
-        current_msg = self.ser.read_until(success.encode())
-        self.ser.timeout = old_timeout
-        if success in current_msg.decode():
-            return current_msg
-        elif failure in current_msg.decode():
-            logging.warning('Failure ({})'.format(current_msg.decode().replace('\r\n', '')))
-        else:
-            logging.error('Receive timeout ({})'.format(current_msg.decode().replace('\r\n', '')))
-        return ''
-
-    def init_modem(self):
-        if self.ser.is_open is True: # on some platforms the serial port needs to be closed first
-            self.ser.close()
-
-        try:
-            self.ser.open()
-        except serial.SerialException as e:
-            logging.error("Could not open serial port {}: {}\n".format(self.ser.name, e))
-            return
-
-        self.ser.write('AT\r'.encode())
-        if self.wait_for('OK', 'ERROR', 3):
-            logging.info('SigFox Modem OK')
-        else:
-            logging.warning('SigFox Modem Init Error')
-            self.ser.close()
-            return
-
-        self.ser.write('ATE0\r'.encode())
-        if self.wait_for('OK', 'ERROR', 3):
-            logging.info('SigFox Modem echo OFF')
-        else:
-            logging.warning('SigFox Modem Configuration Error')
-            self.ser.close()
-            return
-
-        return self.ser
-
-
-    def send_message(self, bytestring):
-
-        self.init_modem()
-
-        if self.ser.is_open:
-            logging.info('Sending SigFox Message...')
-            if len(bytestring) > self.MAX_UPLINK_LENGTH:
-                logging.warning("Message longer than 12 bytes. Truncating ...")
-            self.ser.write("AT$SF={0},2,0\r".format(bytestring[:self.MAX_UPLINK_LENGTH].hex()).encode())
-            logging.info('Sending ...')
-            if self.wait_for('OK', 'ERROR', 15):
-                logging.info('OK Message sent')
-
-        else:
-            logging.error('SigFox Modem Error')
-
-        self.ser.close()
+from sigfox import Sigfox
 
 if __name__ == '__main__':
-
-    if len(sys.argv) == 3:
-        portName = sys.argv[2]
-        sgfx = Sigfox(portName)
-    else:
-        sgfx = Sigfox()
-
+    DEFAULT_PORT = '/dev/ttyAMA0'
     DEFAULT_MESSAGE = "1234CAFE"
-    if len(sys.argv) > 1:
-        message = "{0}".format(sys.argv[1])
-    else:
-        message = DEFAULT_MESSAGE
-    sgfx.send_message(message.encode(encoding="utf-8"))
+
+    try:
+        port_name = sys.argv[2]
+        print('Serial port : ' + port_name)
+    except IndexError:
+        port_name = DEFAULT_PORT
+    sgfx = Sigfox(port_name)
+
+    try:
+        message = bytes.fromhex(sys.argv[1])
+    except IndexError:
+        message = bytes.fromhex(DEFAULT_MESSAGE)
+    logging.getLogger().setLevel(logging.INFO)
+    sgfx.send_message(message)

--- a/sigfox.py
+++ b/sigfox.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python3
+
+## @package rpisigfox
+#  This script allow the control of the rpisigfox expansion board for Raspberry Pi.
+#
+#  V1.0 allow only to send regular message on the SigFox Network.
+#  syntax is :
+#  sendsigfox MESSAGE
+#  where MESSAGE is a HEXA string encoded. Can be 2 to 24 characters representing 1 to 12 bytes.
+#  Example : sendsigfox 00AA55BF to send the 4 bytes 0x00 0xAA 0x55 0xBF
+# 
+
+import re
+import logging
+
+import serial
+
+class Sigfox:
+    MAX_UPLINK_LENGTH = 12 # in bytes
+    DOWNLINK_START_TIMEOUT = 20
+    DOWNLINK_RECEIVE_TIMEOUT = 25
+
+    def __init__(self, port="/dev/ttyAMA0", timeout=None):
+        logging.debug('Serial port : {}'.format(port))
+        self.ser = serial.Serial(
+            port=port,
+            baudrate=9600,
+            parity=serial.PARITY_NONE,
+            stopbits=serial.STOPBITS_ONE,
+            bytesize=serial.EIGHTBITS,
+            timeout=timeout
+        )
+
+    def wait_for(self, success, failure, timeout):
+        return bool(self.receive_until(success, failure, timeout).decode())
+
+    def receive_until(self, success, failure, timeout):
+        old_timeout = self.ser.timeout
+        self.ser.timeout = timeout
+        current_msg = self.ser.read_until(success.encode())
+        logging.debug("Received: '{}' (decoded: '{}')".format(current_msg.hex(), current_msg.decode(errors='replace')))
+        self.ser.timeout = old_timeout
+        if success in current_msg.decode():
+            return current_msg
+        elif failure in current_msg.decode():
+            logging.warning('Failure ({})'.format(current_msg.decode().replace('\r\n', '')))
+        else:
+            logging.error('Receive timeout ({})'.format(current_msg.decode().replace('\r\n', '')))
+        return None
+
+    def init_modem(self):
+        if self.ser.is_open is True: # on some platforms the serial port needs to be closed first
+            self.ser.close()
+
+        try:
+            self.ser.open()
+        except serial.SerialException as e:
+            logging.error("Could not open serial port {}: {}\n".format(self.ser.name, e))
+            return
+
+        self.ser.write('AT\r'.encode())
+        if self.wait_for('OK', 'ERROR', 3):
+            logging.info('SigFox Modem OK')
+        else:
+            logging.warning('SigFox Modem Init Error')
+            self.ser.close()
+            return
+
+        self.ser.write('ATE0\r'.encode())
+        if self.wait_for('OK', 'ERROR', 3):
+            logging.info('SigFox Modem echo OFF')
+        else:
+            logging.warning('SigFox Modem Configuration Error')
+            self.ser.close()
+            return
+
+        return self.ser
+
+    def send_message(self, bytestring):
+
+        self.init_modem()
+
+        if self.ser.is_open:
+            logging.info('Sending SigFox Message...')
+            if len(bytestring) > self.MAX_UPLINK_LENGTH:
+                logging.warning("Trying to send message longer than 12 bytes. Truncating ...")
+                bytestring = bytestring[:self.MAX_UPLINK_LENGTH]
+            self.ser.write("AT$SF={0},2,0\r".format(bytestring.hex()).encode())
+            logging.info('Sending ...')
+            if self.wait_for('OK', 'ERROR', 15):
+                logging.info('OK Message sent')
+                self.ser.close()
+                return bytestring
+            else:
+                logging.error('Error sending message')
+        else:
+            logging.error('SigFox Modem Error')
+
+        self.ser.close()
+        return None
+
+    def send_receive_message(self, bytestring):
+
+        self.init_modem()
+
+        if self.ser.is_open:
+            logging.info('Sending SigFox Message...')
+            if len(bytestring) > self.MAX_UPLINK_LENGTH:
+                logging.warning("Message longer than 12 bytes. Truncating ...")
+            self.ser.write("AT$SF={0},2,1\r".format(bytestring[:self.MAX_UPLINK_LENGTH].hex()).encode())
+            logging.info('Sending ...')
+            if self.wait_for('OK', 'ERROR', 15):
+                logging.info('OK Message sent')
+            else:
+                logging.error('Error sending message')
+                self.ser.close()
+                return None
+
+            if self.wait_for('BEGIN', 'ERROR', self.DOWNLINK_START_TIMEOUT + 2):
+                logging.info('Waiting for answer')
+            else:
+                logging.error('Error waiting for answer')
+                self.ser.close()
+                return None
+
+            rx_data = self.receive_until('END', 'ERROR', self.DOWNLINK_RECEIVE_TIMEOUT + 2)
+            if rx_data:
+                logging.info('Answer received')
+                rx_data = rx_data.decode()
+                logging.debug(rx_data)
+                self.ser.close()
+                match = re.match(r'\+RX=([0-9a-fA-F ]{2,})\+RX END', rx_data.replace('\r\n', ''))
+                if match:
+                    return bytes.fromhex(match.group(1))
+                else:
+                    logging.warning("Malformed or empty answer")
+                    return None
+
+            else:
+                logging.warning('Error receiving answer')
+                self.ser.close()
+                return None
+
+        else:
+            logging.error('SigFox Modem Error')
+            self.ser.close()


### PR DESCRIPTION
Ported to python 3
General code cleanup
Fixed bug on [sendreceivesigfox.py#L121](https://github.com/SNOC/rpisigfox/blob/339c3541744414ddea1a1a45942c5d174023f83a/sendreceivesigfox.py#L121), regex only matches characters a and f, instead of a-f